### PR TITLE
Increase communication suspension duration to allow boiler booting up

### DIFF
--- a/esphome/components/optolink/optolink.h
+++ b/esphome/components/optolink/optolink.h
@@ -22,7 +22,7 @@ class Optolink : public esphome::Component, public Print {
   uint32_t timestamp_send_ = 0;
 
   static const uint32_t COMMUNICATION_CHECK_WINDOW = 10000;
-  static const uint32_t COMMUNICATION_SUSPENSION_DURATION = 10000;
+  static const uint32_t COMMUNICATION_SUSPENSION_DURATION = 60000;
   static const uint32_t MAX_RESPONSE_DELAY = 2000;
 
  public:


### PR DESCRIPTION
Increase communication suspension duration from 10 to 60 seconds. This will allow slower boilers to fully boot up before resuming communication.

This is a workaround for issue #6 .